### PR TITLE
ci: workflowにpermissions設定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-auto-label-assign.yml
+++ b/.github/workflows/pr-auto-label-assign.yml
@@ -5,6 +5,9 @@ on:
     types:
       - review_requested
 
+permissions:
+  pull-requests: write
+
 jobs:
   waiting_for_review:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-auto-label-review.yml
+++ b/.github/workflows/pr-auto-label-review.yml
@@ -5,6 +5,9 @@ on:
     types:
       - submitted
 
+permissions:
+  pull-requests: write
+
 jobs:
   remove:
     if: github.event.review.state == 'approved' || github.event.review.state == 'changes_requested'


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## やったこと

## テスト項目

- [x] CIが正常に実行されること

## レビューに関して

レビューする際には、以下のprefix(接頭辞)を付けましょう。

<!-- for GitHub Copilot review rule -->

| ラベル | 意味                            | 意図                                                               |
| ------ | ------------------------------- | ------------------------------------------------------------------ |
| q      | 質問 (Question)                 | 質問。相手は回答が必要                                             |
| fyi    | 参考まで (For your information) | 参考までに共有。アクションは不要 (確認事項を残す場合などに使用)    |
| nits   | あら捜し (Nitpick)              | 重箱の隅をつつく提案。無視しても良い                               |
| nir    | お手すきで (No rush)            | 今やらなくて良いが、将来的には解決したい提案。タスク化や修正を検討 |
| imo    | 提案 (In my opinion)            | 個人的な見解や、軽微な提案。タスク化や修正を検討                   |
| must   | 必須 (Must)                     | これを直さないと承認できない。修正を検討                           |

<!-- I want to review in Japanese. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Explicitly set GitHub Actions permissions for CI (contents: read) and PR auto-label workflows (pull-requests: write).
> 
> - **GitHub Actions permissions**:
>   - `/.github/workflows/ci.yml`: add `permissions: contents: read`.
>   - `/.github/workflows/pr-auto-label-assign.yml`: add `permissions: pull-requests: write`.
>   - `/.github/workflows/pr-auto-label-review.yml`: add `permissions: pull-requests: write`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d057f4037a07e3a8b0a69563e3cccfe63082eef6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->