### PR TITLE
feat: MCP を APM で宣言し、各エディタ用の設定を追加

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,20 @@
+{
+  "mcpServers": {
+    "linear": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp",
+      "tools": [
+        "*"
+      ],
+      "id": ""
+    },
+    "figma": {
+      "type": "http",
+      "url": "https://mcp.figma.com/mcp",
+      "tools": [
+        "*"
+      ],
+      "id": ""
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "linear": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp"
+    },
+    "figma": {
+      "type": "http",
+      "url": "https://mcp.figma.com/mcp"
+    }
+  }
+}

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,15 @@
+{
+  "servers": {
+    "linear": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp",
+      "headers": {}
+    },
+    "figma": {
+      "type": "http",
+      "url": "https://mcp.figma.com/mcp",
+      "headers": {}
+    }
+  },
+  "inputs": []
+}

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-05-03T18:33:58.260207+00:00'
+generated_at: '2026-05-03T18:59:17.710231+00:00'
 apm_version: 0.12.0
 dependencies:
 - repo_url: vercel-labs/agent-skills
@@ -42,3 +42,17 @@ dependencies:
   - .agents/skills/submit-pr
   - .claude/skills/submit-pr
   content_hash: sha256:17056f9be95b2d534a20dc9912027b941d683778c7b6f46049ec67bc69070d89
+mcp_servers:
+- figma
+- linear
+mcp_configs:
+  figma:
+    name: figma
+    transport: http
+    registry: false
+    url: https://mcp.figma.com/mcp
+  linear:
+    name: linear
+    transport: http
+    registry: false
+    url: https://mcp.linear.app/mcp

--- a/apm.yml
+++ b/apm.yml
@@ -4,10 +4,18 @@ description: APM project for yoshinani-template-base
 author: FukeKazki
 dependencies:
   apm:
-    - yoshinani-dev/skills/skills/submit-pr
-    - vercel-labs/next-skills/skills/next-best-practices
-    - vercel-labs/next-skills/skills/next-cache-components
-    - vercel-labs/agent-skills/skills/react-best-practices
-  mcp: []
+  - yoshinani-dev/skills/skills/submit-pr
+  - vercel-labs/next-skills/skills/next-best-practices
+  - vercel-labs/next-skills/skills/next-cache-components
+  - vercel-labs/agent-skills/skills/react-best-practices
+  mcp:
+    - name: linear
+      registry: false
+      transport: http
+      url: https://mcp.linear.app/mcp
+    - name: figma
+      registry: false
+      transport: http
+      url: https://mcp.figma.com/mcp
 includes: auto
 scripts: {}


### PR DESCRIPTION
## 関連 Issue

該当する Issue はありません。

## 概要

MCP サーバー（Linear / Figma）を `apm.yml` で宣言し、`apm install` とロックファイルで再現可能にしました。Cursor / Claude / VS Code それぞれが参照する MCP 設定ファイルを追加し、HTTP トランスポートで同一エンドポイントに接続できるようにしています。

### 変更内容

- `apm.yml` に `mcp` セクションを追加（linear / figma の HTTP URL を定義）
- `apm.lock.yaml` に `mcp_servers` / `mcp_configs` を反映
- ルート `.mcp.json`（Claude Code 等向け）を追加
- `.cursor/mcp.json` を追加（Cursor 向け、`tools` 等のメタデータ付き）
- `.vscode/mcp.json` を追加（VS Code MCP 拡張向け）

## 動作確認方法

1. リポジトリルートで `apm install` を実行し、エラーなく完了することを確認する
2. Cursor で MCP 設定が読み込まれ、Linear / Figma サーバーが一覧に表示されることを確認する（認証が必要な場合は各サービス側の手順に従う）
3. VS Code で MCP 関連拡張を利用している場合、`.vscode/mcp.json` のサーバー定義が意図どおり参照されることを確認する

## 伝達事項

- MCP の認証は各プロバイダ側のフローに依存します。設定ファイルは URL のみを宣言しています
- エディタごとに JSON のスキーマが異なるため、3 ファイルで形式を揃えています（内容は同一サービス向け）

## レビューに関して

レビューする際には、以下のprefix(接頭辞)を付けましょう。

| ラベル | 意味                            | 意図                                                               |
| ------ | ------------------------------- | ------------------------------------------------------------------ |
| q      | 質問 (Question)                 | 質問。相手は回答が必要                                             |
| fyi    | 参考まで (For your information) | 参考までに共有。アクションは不要 (確認事項を残す場合などに使用)    |
| nits   | あら捜し (Nitpick)              | 重箱の隅をつつく提案。無視しても良い                               |
| nir    | お手すきで (No rush)            | 今やらなくて良いが、将来的には解決したい提案。タスク化や修正を検討 |
| imo    | 提案 (In my opinion)            | 個人的な見解や、軽微な提案。タスク化や修正を検討                   |
| must   | 必須 (Must)                     | これを直さないと承認できない。修正を検討                           |

Made with [Cursor](https://cursor.com)