### PR TITLE
feat: introduce portless for stable named local HTTPS URLs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@
 ## Cursor Cloud specific instructions
 
 - **ランタイム**: Node.js >= 22 と pnpm 10.12.4 が必要（VM環境にプリインストール済み）
-- **開発サーバー**: `apps/web` ディレクトリで `pnpm dev` を実行するとポート3000でNext.js（Turbopack）が起動する
+- **開発サーバー**: `pnpm dev` を実行すると [portless](https://portless.sh/) 経由で Next.js（Turbopack）が `https://web.localhost` に起動する（初回のみローカル CA インストールと sudo プロンプトが必要）
 - **リント/チェック**: CIと同じ非対話的チェックには `pnpm check:ci` を使用（`pnpm check` は自動修正付き）
 - **テスト**: `pnpm test:ci` でVitest単体テストをワンショット実行（`pnpm test` はwatchモード）
 - **外部サービス不要**: データベース、Docker、外部APIへの依存なし。純粋なフロントエンドモノレポ

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Workspace-wide (run from repo root):
 
 | Command | Purpose |
 |---------|---------|
-| `pnpm dev` | Start all dev servers (`apps/web` on :3000) |
+| `pnpm dev` | Start all dev servers (`apps/web` at `https://web.localhost` via portless) |
 | `pnpm build` | Build all packages |
 | `pnpm check` | typecheck + Biome + ESLint **with autofix** (local use) |
 | `pnpm check:ci` | Same checks **without autofix** (CI / verification) |
@@ -41,6 +41,7 @@ Note: `apps/web` `check` runs `next typegen` first (needed because `typedRoutes`
 
 - Node ≥ 22, pnpm 10.12.4 (pinned via `packageManager`); `mise.toml` is the source of truth.
 - `pnpm-workspace.yaml` pre-approves `onlyBuiltDependencies` (sharp, esbuild, etc.) — do **not** run `pnpm approve-builds` interactively.
+- `mise install` also installs [portless](https://portless.sh/) (via `npm:portless`). The `apps/web` dev script invokes `portless web next dev --turbopack`, so the dev URL is `https://web.localhost`. First run installs a local CA and binds :443 (sudo prompt). Don't run `next dev` directly unless you've also done `portless trust`.
 - No databases, Docker, or external services — pure frontend monorepo.
 
 ## Environment variables

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ yoshinani-template-base/
 - Monorepo: Turborepo
 - パッケージマネージャー: pnpm
 - ランタイム管理: mise
+- ローカル HTTPS / 名前付き URL: portless
 - フレームワーク: Next.js 16 (App Router)
   - cacheComponents: 有効化済み
   - reactCompiler: 有効化済み
@@ -38,6 +39,7 @@ yoshinani-template-base/
 - Node.js >= 22
 - pnpm 10.12.4
 - mise (推奨: バージョン管理用)
+- [portless](https://portless.sh/)（ローカル開発で `https://web.localhost` を使うため。`mise install` でまとめて入る）
 
 ## 🚀 セットアップ
 
@@ -53,18 +55,35 @@ cd yoshinani-template-base
 miseを使用する場合（推奨）:
 
 ```bash
-mise install
+mise install            # Node.js / pnpm / portless をまとめて取得
 pnpm install
 ```
 
 miseを使用しない場合:
 
 ```bash
-# Node.js 22以上とpnpm 10.12.4を手動でインストール
+# Node.js 22以上 / pnpm 10.12.4 / portless を手動でインストール
+npm install -g portless
 pnpm install
 ```
 
-### 3. VS Code拡張機能のインストール（推奨）
+### 3. portless（ローカル HTTPS）の初回セットアップ
+
+`apps/web` の `pnpm dev` は [portless](https://portless.sh/) 経由で `https://web.localhost` に起動します。初回起動時に以下が自動で行われます。
+
+- ローカル CA の生成・OS の信頼ストアへの登録（sudo プロンプトが出ます）
+- HTTPS プロキシによる :443 のバインド
+- Next.js への `PORT` 環境変数の自動注入（ポート競合の心配なし）
+
+事前に CA だけ入れておきたい場合は、リポジトリ外でも以下を実行できます。
+
+```bash
+portless trust          # ローカル CA を OS の信頼ストアに追加
+```
+
+Git worktree でブランチを並行開発する際は、portless が worktree を検出し `https://<branch>.web.localhost` のように自動でサブドメインを切ってくれます。
+
+### 4. VS Code拡張機能のインストール（推奨）
 
 このプロジェクトで使用しているVS Codeの推奨拡張機能をインストールすることを推奨します:
 
@@ -136,7 +155,7 @@ NEXT_PUBLIC_APP_NAME="My App"
 pnpm dev
 ```
 
-`apps/web`が `http://localhost:3000` で起動します。
+`apps/web` が `https://web.localhost` で起動します（portless 経由）。ポート番号を意識せずに HTTPS でアクセスでき、Cookie の `Secure` / `SameSite=None` など本番に近い条件で検証できます。
 
 ### 個別のパッケージでの開発
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "portless web next dev --turbopack",
     "build": "next build",
     "check": "next typegen && tsc --noEmit && biome check --write . && eslint . --max-warnings 0 --fix",
     "check:ci": "next typegen && tsc --noEmit && biome check . && eslint . --max-warnings 0",

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,4 @@
 [tools]
 node = "22"
 pnpm = "10"
+"npm:portless" = "latest"


### PR DESCRIPTION
Closes #103

## Summary

- `mise.toml`: add `"npm:portless" = "latest"` so `mise install` installs the [portless](https://portless.sh/) CLI alongside Node/pnpm
- `apps/web` の `dev` スクリプトを `portless web next dev --turbopack` に変更。`pnpm dev` で `https://web.localhost` が立ち上がる
- README / CLAUDE.md / AGENTS.md: 要件、セットアップ手順、開発サーバー URL、エージェント向け説明を更新（ローカル CA の sudo プロンプトに触れる）

## 採用方針

- 名前空間: `web.localhost`（必要になれば `api.web.localhost` のようにサブドメインを増やせる）
- portless は dev 専用ツールなので devDependency ではなく **mise でグローバル管理**（issue の方針どおり）
- CI（`check.yml` / `test.yml`）は mise を使わず `pnpm/action-setup` + `actions/setup-node` で進むので、`mise.toml` への追加で CI が落ちることはない（履歴の Check ジョブも引き続き green）

## 動作確認

- `pnpm install --frozen-lockfile && pnpm check:ci` 通過
- `pnpm test:ci` 通過
- `pnpm --filter web dev` で portless 経由起動を確認:
  ```
  Running: PORT=4174 HOST=127.0.0.1 PORTLESS_URL=https://web.localhost ... next dev --turbopack
  ▲ Next.js 16.2.6 (Turbopack)
  ✓ Ready in 196ms
  ```
- `curl -skI https://web.localhost` → `HTTP/2 200`（`x-portless: 1` ヘッダーあり、Next.js HTML が返る）

## Test plan

- [ ] `mise install` で portless が入る
- [ ] 初回 `pnpm dev` 実行時にローカル CA のインストール（sudo プロンプト）が走り、その後 `https://web.localhost` で開ける
- [ ] Git worktree から `pnpm dev` を実行すると `https://<branch>.web.localhost` で開ける
- [ ] CI の `check` / `test` ジョブが green

🤖 Generated with [Claude Code](https://claude.com/claude-code)