### PR TITLE
fix: PRコメント通知をURLのみに変更

### DIFF
--- a/.github/workflows/weekly-pr-comments.yml
+++ b/.github/workflows/weekly-pr-comments.yml
@@ -111,18 +111,22 @@ jobs:
           # URLのみを改行区切りで抽出
           MESSAGE=$(echo "$COMMENTS" | jq -r '.[] | .url' | paste -sd '\n' -)
           
-          # Slack Webhook で送信
-          curl -X POST "$SLACK_WEBHOOK_URL" \
-            -H 'Content-Type: application/json' \
-            -d "$(jq -n \
-              --arg text "$MESSAGE" \
-              --arg channel "notify-pr-comments" \
-              '{
-                channel: $channel,
-                username: "PR Comments Bot",
-                icon_emoji: ":memo:",
-                text: $text
-              }')"
+          # メッセージが空でないことを確認してから送信
+          if [ -n "$MESSAGE" ]; then
+            curl -X POST "$SLACK_WEBHOOK_URL" \
+              -H 'Content-Type: application/json' \
+              -d "$(jq -n \
+                --arg text "$MESSAGE" \
+                --arg channel "notify-pr-comments" \
+                '{
+                  channel: $channel,
+                  username: "PR Comments Bot",
+                  icon_emoji: ":memo:",
+                  text: $text
+                }')"
+          else
+            echo "メッセージが空のため、Slack通知をスキップしました"
+          fi
 
       - name: Summary
         run: |

--- a/.github/workflows/weekly-pr-comments.yml
+++ b/.github/workflows/weekly-pr-comments.yml
@@ -107,14 +107,9 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
           COMMENTS='${{ steps.collect.outputs.comments }}'
-          COUNT='${{ steps.collect.outputs.count }}'
           
-          # Slack メッセージを構築
-          MESSAGE="📌 *直近1週間で👍が付いたPRコメント（${COUNT}件）*\n\n"
-          
-          echo "$COMMENTS" | jq -r '.[] | "• <\(.url)|\(.type | if . == "conversation" then "Conversation" else "Review" end)> by @\(.author)\n  \(.body | gsub("\n"; " "))...\n"' | while IFS= read -r line; do
-            MESSAGE="${MESSAGE}${line}"
-          done
+          # URLのみを改行区切りで抽出
+          MESSAGE=$(echo "$COMMENTS" | jq -r '.[] | .url' | paste -sd '\n' -)
           
           # Slack Webhook で送信
           curl -X POST "$SLACK_WEBHOOK_URL" \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

週次PRコメント通知のSlackメッセージを簡素化し、URLのみを送信するように修正しました。また、該当コメントが0件の場合は確実に通知を送信しないように改善しました。

### 変更内容

- ヘッダーメッセージ (`📌 *直近1週間で👍が付いたPRコメント（N件）*`) を削除
- コメント詳細（タイプ、作成者、本文プレビュー）の表示を削除
- 👍が付いたPRコメントのURLのみを改行区切りで送信するように変更
- **該当コメントが0件の場合、Slack通知を送信しないように二重チェックを追加**

## 変更ファイル

- `.github/workflows/weekly-pr-comments.yml`
  - `Send to Slack` ステップを簡素化
  - jqコマンドで`.url`のみを抽出するように変更
  - メッセージが空の場合の安全性チェックを追加

## セーフティチェック

該当コメントがない場合の通知送信を防ぐため、以下の2段階チェックを実装:

1. **ステップレベル**: `if: steps.collect.outputs.count > 0` - コメント数が0より大きい場合のみステップを実行
2. **スクリプトレベル**: `if [ -n "$MESSAGE" ]` - メッセージが空でない場合のみcurlを実行

## 動作確認方法

### ケース1: 該当コメントがある場合
1. 直近1週間に👍リアクション付きPRコメントを作成
2. ワークフローを手動実行 (workflow_dispatch)
3. SlackにURLのみが送信されることを確認

### ケース2: 該当コメントがない場合
1. 直近1週間に👍リアクション付きPRコメントがない状態にする
2. ワークフローを手動実行
3. Slack通知が送信されないことを確認
4. GitHub Actions のサマリーに「該当するコメントはありませんでした」と表示されることを確認

## 伝達事項

- Slackメッセージがよりシンプルになり、素早くコメントにアクセスできます
- URLのプレビュー機能によって、Slack上でコメント内容が自動展開されるため、詳細情報は不要と判断しました
- 該当コメントがない週は通知が送信されないため、ノイズが削減されます

## レビューに関して

レビューする際には、以下のprefix(接頭辞)を付けましょう。

| ラベル | 意味                            | 意図                                                               |
| ------ | ------------------------------- | ------------------------------------------------------------------ |
| q      | 質問 (Question)                 | 質問。相手は回答が必要                                             |
| fyi    | 参考まで (For your information) | 参考までに共有。アクションは不要 (確認事項を残す場合などに使用)    |
| nits   | あら捜し (Nitpick)              | 重箱の隅をつつく提案。無視しても良い                               |
| nir    | お手すきで (No rush)            | 今やらなくて良いが、将来的には解決したい提案。タスク化や修正を検討 |
| imo    | 提案 (In my opinion)            | 個人的な見解や、軽微な提案。タスク化や修正を検討                   |
| must   | 必須 (Must)                     | これを直さないと承認できない。修正を検討                           |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e27eb6e-5ac5-478f-ae23-db1104e5ce5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e27eb6e-5ac5-478f-ae23-db1104e5ce5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

